### PR TITLE
Bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,9 @@
     "piano"
   ],
   "license": "MIT",
+  "dependencies": {
+    "raphael": "2.1.x"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
If this is merged into `master`, it'll need to be tagged as version 0.2.0 so that Bower will work.

```
$ git tag -a v0.2.0
```

After that happens, you'll be able to `bower install qwerty-hancock`, which is sweet.
