### PR TITLE
Fixed incorrect path in bower.json main field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "qwerty-hancock",
-    "main": "src/qwerty-hancock.js",
+    "main": "dist/qwerty-hancock.js",
     "version": "0.4.4",
     "homepage": "http://stuartmemo.com/qwerty-hancock/",
     "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "qwerty-hancock",
-    "main": "qwerty-hancock.js",
-    "version": "0.4.3",
+    "main": "src/qwerty-hancock.js",
+    "version": "0.4.4",
     "homepage": "http://stuartmemo.com/qwerty-hancock/",
     "authors": [
         {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "qwerty-hancock",
   "title": "Qwerty Hancock",
   "description": "An interactive HTML plugin-free keyboard for your web audio project.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:stuartmemo/qwerty-hancock.git"


### PR DESCRIPTION
The bower file's main pointed to the wrong file so wouldn't be loaded.
 
Added the missing "src/" prefix.

--

Very useful library/widget/:musical_keyboard: 

Using it for a voice/formant synth thing at the moment http://formant-synth.meteor.com/