### PR TITLE
Fix phantom note from extra space.

### DIFF
--- a/src/qwerty-hancock.js
+++ b/src/qwerty-hancock.js
@@ -237,18 +237,22 @@
     * Call user's mouseDown event.
     */
     var mouseDown = function (element, callback) {
-        mouse_is_down = true;
-        lightenUp(element);
-        callback(element.title, getFrequencyOfNote(element.title));
+        if (element.tagName.toLowerCase() == 'li') {
+            mouse_is_down = true;
+            lightenUp(element);
+            callback(element.title, getFrequencyOfNote(element.title));
+        }
     };
 
     /**
     * Call user's mouseUp event.
     */
     var mouseUp = function (element, callback) {
-        mouse_is_down = false;
-        darkenDown(element);
-        callback(element.title, getFrequencyOfNote(element.title));
+        if (element.tagName.toLowerCase() == 'li') {
+            mouse_is_down = false;
+            darkenDown(element);
+            callback(element.title, getFrequencyOfNote(element.title));
+        }
     };
 
     /**


### PR DESCRIPTION
In cases where the available space for the keyboard is not evenly divisible by the number of white keys, some extra space exists to the right of the keyboard.  Without this fix, this space is playable as a phantom key that produces a low frequency.  You can reproduce this on the Qwerty Hancock demo page by clicking just to the right of the last white key.  This fix simply checks that the clicked element tag is 'li' prior to playing the note.