### PR TITLE
Support qwerty-hancock as a requirable module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,17 @@ module.exports = function (grunt) {
             }
         },
 
+        jasmine_node: {
+          options: {
+            forceExit: true,
+            match: '.',
+            matchall: false,
+            extensions: 'js',
+            specNameMatcher: 'spec'
+          },
+          spec: ['tests/qh-node-spec']
+        },
+
         uglify: {
             dist: {
                 files: {
@@ -38,9 +49,10 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-karma');
+    grunt.loadNpmTasks('grunt-jasmine-node');
 
     // Tasks.
     grunt.registerTask('default', ['uglify']);
     grunt.registerTask('build', ['copy', 'uglify']);
-    grunt.registerTask('test', ['karma']);
+    grunt.registerTask('test', ['jasmine_node:spec', 'karma']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
         pkg: grunt.file.readJSON('package.json'),
 
         copy: {
-            main: { 
+            main: {
                 expand: true,
                 filter: 'isFile',
                 cwd: 'src/',

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -23,14 +23,14 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
-      
+
     ],
 
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-    
+
     },
 
 

--- a/karma-conf.js
+++ b/karma-conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
     files: [
         'lib/key-simulator.js',
         'src/qwerty-hancock.js',
-        'tests/*.js'      
+        'tests/*-tests.js'      
     ],
 
 

--- a/lib/key-simulator.js
+++ b/lib/key-simulator.js
@@ -7,12 +7,12 @@ var pressKey = function(k) {
         get : function() {
             return this.keyCodeVal;
         }
-    });     
+    });
     Object.defineProperty(oEvent, 'which', {
         get : function() {
             return this.keyCodeVal;
         }
-    });     
+    });
 
     if (oEvent.initKeyboardEvent) {
         oEvent.initKeyboardEvent('keydown', true, true, document.defaultView, false, false, false, false, k, k);

--- a/package.json
+++ b/package.json
@@ -11,17 +11,18 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-uglify": "latest",
-    "grunt-requirejs": "~0.4.2",
+    "grunt-jasmine-node": "^0.3.1",
+    "grunt-karma": "~0.8.3",
+    "jsdom": "^3.x.x",
     "karma": "~0.12.16",
-    "karma-jasmine": "~0.2.2",
     "karma-chrome-launcher": "~0.1.4",
     "karma-firefox-launcher": "~0.1.3",
-    "karma-safari-launcher": "~0.1.1",
-    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-jasmine": "~0.2.2",
     "karma-opera-launcher": "~0.1.0",
-    "grunt-karma": "~0.8.3",
-    "grunt-contrib-copy": "^0.5.0"
+    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-safari-launcher": "~0.1.1"
   },
   "scripts": {
     "test": "./node_modules/karma/bin/karma start ./karma-conf.js --browsers Firefox --single-run"

--- a/src/qwerty-hancock.js
+++ b/src/qwerty-hancock.js
@@ -9,7 +9,12 @@
  * http://stuartmemo.com/qwerty-hancock
  */
 
-(function (window, undefined) {
+(function () {
+    var root = this;
+    /* In <script> context, `this` is the window.
+     * In node context (browserify), `this` is the node global.
+     */
+    var globalWindow = typeof global === 'undefined' ? root : root.window;
     var version = '0.4.5',
         settings = {},
         mouse_is_down = false,
@@ -437,12 +442,12 @@
         var that = this;
 
         // Key is pressed down on keyboard.
-        window.addEventListener('keydown', function (key) {
+        globalWindow.addEventListener('keydown', function (key) {
             keyboardDown(key, that.keyDown);
         });
- 
+
         // Key is released on keyboard.
-        window.addEventListener('keyup', function (key) {
+        globalWindow.addEventListener('keyup', function (key) {
             keyboardUp(key, that.keyUp);
         });
 
@@ -504,5 +509,12 @@
         init.call(this, settings);
     };
 
-    window.QwertyHancock = QwertyHancock;
-})(window);
+    if (typeof exports !== 'undefined') {
+      if (typeof module !== 'undefined' && module.exports) {
+        exports = module.exports = QwertyHancock;
+      }
+      exports.QwertyHancock = QwertyHancock;
+    } else {
+      root.QwertyHancock = QwertyHancock;
+    }
+})(this);

--- a/src/qwerty-hancock.js
+++ b/src/qwerty-hancock.js
@@ -278,7 +278,7 @@
             callback(element.title, getFrequencyOfNote(element.title));
         }
     };
- 
+
     /**
     * Create key DOM element.
     * @return {object} Key DOM element.
@@ -359,7 +359,7 @@
     var setKeyPressOffset = function (sorted_white_notes) {
         settings.keyPressOffset = sorted_white_notes[0] === 'C' ? 0 : 1;
     };
-    
+
     var createKeyboard = function () {
         var keyboard = {
             container: document.getElementById(settings.id),
@@ -410,7 +410,7 @@
             lightenUp(document.getElementById(key_pressed));
        }
     };
- 
+
     /**
      * Handle a keyboard key being released.
      * @param {element} key The DOM element of the key that was released.
@@ -483,7 +483,7 @@
             keyboard_element.addEventListener('touchcancel', function (event) {
                 mouseOut(event.target, that.keyUp);
             });
-        } 
+        }
     };
 
     /**

--- a/tests/helpers/test-dom.js
+++ b/tests/helpers/test-dom.js
@@ -1,0 +1,10 @@
+/* jshint browser: true, node: true */
+'use strict';
+
+var jsdom = require('jsdom').jsdom;
+
+
+module.exports = function (markup) {
+  global.document = jsdom(markup || '');
+  global.window = document.parentWindow;
+};

--- a/tests/qh-node-spec.js
+++ b/tests/qh-node-spec.js
@@ -1,0 +1,84 @@
+/* jshint browser: true, jasmine: true, node: true */
+'use strict';
+
+var testDom = require('./helpers/test-dom');
+
+
+describe('QwertyHancock', function () {
+  var element, QwertyHancock;
+
+  beforeEach(function () {
+    testDom('<html><body></body></html>');
+    element = document.createElement('div');
+    element.id = 'keyboard';
+    document.body.appendChild(element);
+    QwertyHancock = require('../src/qwerty-hancock');
+  });
+
+  it('is node requirable', function () {
+    expect(QwertyHancock).toExist;
+  });
+
+  it('Can create keyboard without any user settings', function () {
+      var qh = new QwertyHancock();
+
+      expect(element.id).toBe('keyboard');
+      expect(element.querySelectorAll('li').length).toBeGreaterThan(0);
+  });
+
+  it('Can create keyboard with user specified dimensions', function () {
+      var qh = new QwertyHancock({width: 500, height: 300});
+
+      expect(element.style.width).toBe('500px');
+      expect(element.style.height).toBe('300px');
+  });
+
+  it('White keys should be white by default', function () {
+      var qh = new QwertyHancock(),
+          white_keys = element.querySelectorAll('li[data-note-type="white"]');
+
+      for (var i = 0; i < white_keys.length; i++) {
+          expect(white_keys[i].style.backgroundColor).toBe('rgb(255, 255, 255)');
+      }
+  });
+
+  it('Black keys should be black by default', function () {
+      var qh = new QwertyHancock(),
+          black_keys = element.querySelectorAll('li[data-note-type="black"]');
+
+      for (var i = 0; i < black_keys.length; i++) {
+          expect(black_keys[i].style.backgroundColor).toBe('rgb(0, 0, 0)');
+      }
+  });
+
+  it('White keys should be user defined colour', function () {
+      var qh = new QwertyHancock({whiteKeyColour: '#333'}),
+          white_keys = element.querySelectorAll('li[data-note-type="white"]');
+
+      for (var i = 0; i < white_keys.length; i++) {
+          expect(white_keys[i].style.backgroundColor).toBe('rgb(51, 51, 51)');
+      }
+  });
+
+  it('Black keys should be user defined colour', function () {
+      var qh = new QwertyHancock({blackKeyColour: 'red'}),
+          black_keys = element.querySelectorAll('li[data-note-type="black"]');
+
+      for (var i = 0; i < black_keys.length; i++) {
+          expect(black_keys[i].style.backgroundColor).toBe('red');
+      }
+  });
+
+  it('First key on keyboard should be user defined note', function () {
+      var qh = new QwertyHancock({startNote: 'C4'}),
+          first_white_key = element.querySelector('li[data-note-type="white"]');
+
+      expect(first_white_key.id).toBe('C4');
+  });
+
+  afterEach(function () {
+    document.body.removeChild(element);
+    delete global.document;
+    delete global.window;
+  });
+});

--- a/tests/qh-tests.js
+++ b/tests/qh-tests.js
@@ -29,7 +29,7 @@ describe('Qwerty Hancock tests', function () {
         element.style.width = '200px';
         element.style.height = '100px';
 
-        qh = new QwertyHancock(); 
+        qh = new QwertyHancock();
 
         expect(element.querySelector('ul').style.width).toBe(element.style.width);
         expect(element.querySelector('ul').style.height).toBe(element.style.height);
@@ -38,7 +38,7 @@ describe('Qwerty Hancock tests', function () {
     it('White keys should be white by default', function () {
         var qh = new QwertyHancock(),
             white_keys = element.querySelectorAll('li[data-note-type="white"]');
-                
+
         for (var i = 0; i < white_keys.length; i++) {
             expect(white_keys[i].style.backgroundColor).toBe('rgb(255, 255, 255)');
         }
@@ -56,7 +56,7 @@ describe('Qwerty Hancock tests', function () {
     it('White keys should be user defined colour', function () {
         var qh = new QwertyHancock({whiteKeyColour: '#333'}),
             white_keys = element.querySelectorAll('li[data-note-type="white"]');
-    
+
         for (var i = 0; i < white_keys.length; i++) {
             expect(white_keys[i].style.backgroundColor).toBe('rgb(51, 51, 51)');
         }


### PR DESCRIPTION
I wanted to use qwerty-hancock for a small project, but I bundle all my `.js` files with browserify.

This PR:
+ Creates simple checks for whether the environment is a browser or node. If the former, qwerty-hancock will know it is being used in the `<script>` context and carry on as usual. If the latter, qwerty-hancock will become exportable and can be required as a module.
+ Add testing libraries (`jsdom`, `grunt-jasmine-node`), helpers, and specs to confirm this
+ Cleans up some whitespace
+ Remove `grunt-requirejs` package. It was unused.

Notes:
+ I didn't run the build task, so the `dist/qwerty-hancock` hasn't been modified.
+ Need to add the "main" property in the `package.json` (probably `dist/qwerty-hancock.js` after running the build task)

Suggestions and comments are of course welcome
