### PR TITLE
Prevent keyboard from playing if modifier key is pressed

### DIFF
--- a/lib/key-simulator.js
+++ b/lib/key-simulator.js
@@ -1,5 +1,6 @@
 // via http://stackoverflow.com/questions/10455626/keydown-simulation-in-chrome-fires-normally-but-not-the-correct-key/10520017#10520017
-var pressKey = function(k) {
+var pressKey = function(k, options) {
+    options = options || {};
     var oEvent = document.createEvent('KeyboardEvent');
 
     // Chromium Hack
@@ -15,7 +16,17 @@ var pressKey = function(k) {
     });
 
     if (oEvent.initKeyboardEvent) {
-        oEvent.initKeyboardEvent('keydown', true, true, document.defaultView, false, false, false, false, k, k);
+        oEvent.initKeyboardEvent('keydown',
+            true, // bubbles
+            true, // cancelable
+            document.defaultView, // viewArg: should be window
+            false, // ctrlKeyArg
+            false, // altKeyArg
+            false, // shiftKeyArg
+            !!options.metaKey, // metaKeyArg
+            k, // keyCodeArg : unsigned long the virtual key code, else 0
+            0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
+        );
     } else {
         oEvent.initKeyEvent('keydown', true, true, document.defaultView, false, false, false, false, k, 0);
     }

--- a/lib/key-simulator.js
+++ b/lib/key-simulator.js
@@ -15,8 +15,8 @@ var pressKey = function(k, options) {
         }
     });
 
-    if (oEvent.initKeyboardEvent) {
-        oEvent.initKeyboardEvent('keydown',
+    if (oEvent.initKeyEvent) {
+        oEvent.initKeyEvent('keydown',
             true, // bubbles
             true, // cancelable
             document.defaultView, // viewArg: should be window
@@ -28,7 +28,17 @@ var pressKey = function(k, options) {
             0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
         );
     } else {
-        oEvent.initKeyEvent('keydown', true, true, document.defaultView, false, false, false, false, k, 0);
+        oEvent.initKeyboardEvent('keydown',
+            true, // bubbles
+            true, // cancelable
+            document.defaultView, // viewArg: should be window
+            false, // ctrlKeyArg
+            false, // altKeyArg
+            false, // shiftKeyArg
+            !!options.metaKey, // metaKeyArg
+            k, // keyCodeArg : unsigned long the virtual key code, else 0
+            0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
+        );
     }
 
     oEvent.keyCodeVal = k;

--- a/src/qwerty-hancock.js
+++ b/src/qwerty-hancock.js
@@ -435,6 +435,14 @@
     };
 
     /**
+     * Determine whether pressed key is a modifier key or not.
+     * @param {KeyboardEvent} The keydown event of a pressed key
+     */
+    var isModifierKey = function (key) {
+        return key.ctrlKey ||  key.metaKey || key.altKey;
+    };
+
+    /**
      * Add event listeners to keyboard.
      * @param {element} keyboard_element
      */
@@ -443,11 +451,17 @@
 
         // Key is pressed down on keyboard.
         globalWindow.addEventListener('keydown', function (key) {
+            if (isModifierKey(key)) {
+              return;
+            }
             keyboardDown(key, that.keyDown);
         });
 
         // Key is released on keyboard.
         globalWindow.addEventListener('keyup', function (key) {
+            if (isModifierKey(key)) {
+              return;
+            }
             keyboardUp(key, that.keyUp);
         });
 

--- a/tests/qh-tests.js
+++ b/tests/qh-tests.js
@@ -87,6 +87,16 @@ describe('Qwerty Hancock tests', function () {
         expect(c4_key.style.backgroundColor).toBe('yellow');
     });
 
+    it('When user presses modifier key on computer keyboard, related keyboard key should not change colour', function () {
+        var qh = new QwertyHancock(),
+            d4_key = document.querySelector('#D4');
+
+        pressKey(83, { metaKey: true });
+
+        expect(d4_key.style.backgroundColor).not.toBe('yellow');
+        expect(d4_key.style.backgroundColor).toBe('rgb(255, 255, 255)');
+    });
+
     afterEach(function () {
         document.body.removeChild(element);
     });


### PR DESCRIPTION
Fixes: https://github.com/stuartmemo/qwerty-hancock/issues/9

This PR: 

+ Adds a check to the keydown callback to return out if a modifier key is pressed before an actual key. 
+ Expands the key-simulator test helper to enable keyboardEvent.metaKey testing
+ Adds a simple test for this functionality. 

Something I noticed though is that even though this works for something like Cmd + L, if someone did L + Cmd, it will still hold the L at keydown until pressed again.