### PR TITLE
Enable qwerty-hancock to remove its events

### DIFF
--- a/src/qwerty-hancock.js
+++ b/src/qwerty-hancock.js
@@ -58,10 +58,8 @@
      * Merge user settings with defaults.
      * @param  {object} user_settings
      */
-    var init = function (us) {
+    var init = function (user_settings) {
         var container;
-
-        user_settings = us || {};
 
         settings = {
             id:             user_settings.id || 'keyboard',
@@ -89,7 +87,6 @@
         settings.startOctave = parseInt(settings.startNote.charAt(1), 10);
 
         createKeyboard();
-        addListeners.call(this, container);
     };
 
     /**
@@ -443,73 +440,11 @@
     };
 
     /**
-     * Add event listeners to keyboard.
-     * @param {element} keyboard_element
-     */
-    var addListeners = function (keyboard_element) {
-        var that = this;
-
-        // Key is pressed down on keyboard.
-        globalWindow.addEventListener('keydown', function (key) {
-            if (isModifierKey(key)) {
-              return;
-            }
-            keyboardDown(key, that.keyDown);
-        });
-
-        // Key is released on keyboard.
-        globalWindow.addEventListener('keyup', function (key) {
-            if (isModifierKey(key)) {
-              return;
-            }
-            keyboardUp(key, that.keyUp);
-        });
-
-        // Mouse is clicked down on keyboard element.
-        keyboard_element.addEventListener('mousedown', function (event) {
-            mouseDown(event.target, that.keyDown);
-        });
-
-        // Mouse is released from keyboard element.
-        keyboard_element.addEventListener('mouseup', function (event) {
-            mouseUp(event.target, that.keyUp);
-        });
-
-        // Mouse is moved over keyboard element.
-        keyboard_element.addEventListener('mouseover', function (event) {
-            mouseOver(event.target, that.keyDown);
-        });
-
-        // Mouse is moved out of keyvoard element.
-        keyboard_element.addEventListener('mouseout', function (event) {
-            mouseOut(event.target, that.keyUp);
-        });
-
-        // Device supports touch events.
-        if ('ontouchstart' in document.documentElement) {
-            keyboard_element.addEventListener('touchstart', function (event) {
-                mouseDown(event.target, that.keyDown);
-            });
-
-            keyboard_element.addEventListener('touchend', function (event) {
-                mouseUp(event.target, that.keyUp);
-            });
-
-            keyboard_element.addEventListener('touchleave', function (event) {
-                mouseOut(event.target, that.keyUp);
-            });
-
-            keyboard_element.addEventListener('touchcancel', function (event) {
-                mouseOut(event.target, that.keyUp);
-            });
-        }
-    };
-
-    /**
      * Qwerty Hancock constructor.
      * @param {object} settings Optional user settings.
      */
     var QwertyHancock = function (settings) {
+        settings = settings || {};
         this.version = version;
 
         this.keyDown = function () {
@@ -521,6 +456,76 @@
         };
 
         init.call(this, settings);
+
+        // Add event listeners to the keyboard and browser window.
+        var keyboard_element = document.getElementById(settings.id || 'keyboard');
+        var keyDown = this.keyDown;
+        var keyUp = this.keyUp;
+
+        var keyboardKeyDown = function(key) {
+          if (isModifierKey(key)) {
+            return;
+          }
+          keyboardDown(key, keyDown);
+        };
+        var keyboardKeyUp = function(key) {
+          if (isModifierKey(key)) {
+            return;
+          }
+          keyboardUp(key, keyUp);
+        };
+        var mouseClickDown = function (event) {
+            mouseDown(event.target, keyDown);
+        };
+        var mouseClickUp = function (event) {
+            mouseUp(event.target, keyUp);
+        };
+        var mouseClickOver = function (event) {
+            mouseOver(event.target, keyUp);
+        };
+        var mouseClickOut = function (event) {
+            mouseOut(event.target, keyUp);
+        };
+
+        // Key is pressed down on keyboard.
+        globalWindow.addEventListener('keydown', keyboardKeyDown);
+
+        // Key is released on keyboard.
+        globalWindow.addEventListener('keyup', keyboardKeyUp);
+
+        // Mouse is clicked down on keyboard element.
+        keyboard_element.addEventListener('mousedown', mouseClickDown);
+
+        // Mouse is released from keyboard element.
+        keyboard_element.addEventListener('mouseup', mouseClickUp);
+
+        // Mouse is moved over keyboard element.
+        keyboard_element.addEventListener('mouseover', mouseClickOver);
+
+        // Mouse is moved out of keyboard element.
+        keyboard_element.addEventListener('mouseout', mouseClickOut);
+
+        // Device supports touch events.
+        if ('ontouchstart' in document.documentElement) {
+            keyboard_element.addEventListener('touchstart', mouseClickDown);
+            keyboard_element.addEventListener('touchend', mouseClickUp);
+            keyboard_element.addEventListener('touchleave', mouseClickOut);
+            keyboard_element.addEventListener('touchcancel', mouseClickOut);
+        }
+
+        this.removeEvents = function () {
+          globalWindow.removeEventListener('keydown', keyboardKeyDown);
+          globalWindow.removeEventListener('keyup', keyboardKeyUp);
+          keyboard_element.removeEventListener('mousedown', mouseClickDown);
+          keyboard_element.removeEventListener('mouseup', mouseClickUp);
+          keyboard_element.removeEventListener('mouseover', mouseClickOver);
+          keyboard_element.removeEventListener('mouseout', mouseClickOut);
+          keyboard_element.removeEventListener('touchstart', mouseClickDown);
+          keyboard_element.removeEventListener('touchend', mouseClickUp);
+          keyboard_element.removeEventListener('touchleave', mouseClickOut);
+          keyboard_element.removeEventListener('touchcancel', mouseClickOut);
+        }
+
     };
 
     if (typeof exports !== 'undefined') {

--- a/tests/qh-tests.js
+++ b/tests/qh-tests.js
@@ -9,6 +9,25 @@ describe('Qwerty Hancock tests', function () {
         document.body.appendChild(element);
     });
 
+    describe('removeEvents()', function () {
+        it('removes all event listeners that were added by Qwerty Hancock', function () {
+            var qh = new QwertyHancock(),
+                e4_key = document.querySelector('#E4'),
+                f4_key = document.querySelector('#F4');
+
+            pressKey(68); // 'D' on the computer keyboard
+
+            expect(e4_key.style.backgroundColor).toBe('yellow');
+
+            qh.removeEvents();
+
+            pressKey(70); // 'F' on the computer keyboard
+
+            expect(f4_key.style.backgroundColor).not.toBe('yellow');
+            expect(f4_key.style.backgroundColor).toBe('rgb(255, 255, 255)');
+        });
+    });
+
     it('Can create keyboard without any user settings', function () {
         var qh = new QwertyHancock();
 


### PR DESCRIPTION
Hi @stuartmemo, this is a pretty weird looking PR, but I'll try my best to explain it.

An unexpected problem that occurred was if the qwerty-hancock keyboard was removed from the DOM, its keyboard listeners still existed on the `window`. A real case example of this is if a user switched views, their computer keyboard would still play sounds despite the keyboard UI not being visible.

However removing event listeners requires the specific named function instance that was added. Since the former `addListeners` function added unnamed functions, I had to extract these functions out into their own variables so that `addEventListener` and `removeEventListener` would have a named function to bind/unbind.

However this brought up the problem with using `this.keyDown`/`this.keyUp` that lives on the actual `QwertyHancock` class. The new named functions needed `this` to be scoped in, but there wasn't a good place to do so outside of the class. I tried variations such as using `bind`, but `removeEventListener` insists on the actual function that was passed to `addEventListener`, unmodified.

This is why I moved the `addListener` functionality into the `QwertyHancock` class, doing it automatically after `init.call`. This allowed me to create the `QwertyHancock.removeEvents` function, which calls `removeEventListener` on all the specific named functions that were added.

For the added spec, I had to place it as the first test because each `var qh = new QwertyHancock()` declaration from other tests adds their set of keydown/keyup listeners onto the `window`.

Suggestions, questions, and/or comments are of course welcome.

**Edit**
You can test this out locally by doing `keyboard.removeEvents();` in the javascript console.